### PR TITLE
Beastie Dockerfile updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM gcc:11 AS CMDSTAN
+FROM ubuntu:20.10 AS CMDSTAN
 
 WORKDIR /
-RUN apt-get update; apt-get install --no-install-recommends -qq wget ca-certificates
+RUN apt-get update; apt-get install --no-install-recommends -qq wget ca-certificates make gcc g++
 
 RUN wget https://github.com/stan-dev/cmdstan/releases/download/v2.27.0/cmdstan-2.27.0.tar.gz
 RUN tar -zxpf cmdstan-2.27.0.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV CYTHONIZE 1
 RUN apt-get update \
   && apt-get install -y --no-install-recommends make gcc g++ \
-  && apt-get install -y --no-install-recommends r-base-core r-base-dev libicu67 libstdc++6 openssl libxml2 libcurl4 zlib1g libbz2-1.0 lzma libhts3 vcftools samtools pipenv python3.8-venv \
+  && apt-get install -y --no-install-recommends r-base-core r-base-dev libicu67 libstdc++6 openssl libxml2 libcurl4 zlib1g libbz2-1.0 lzma libhts3 vcftools samtools pipenv python3.8-venv tabix libtbb2 \
   && apt-get install -y --no-install-recommends libicu-dev libxml2-dev git autoconf zlib1g-dev libbz2-dev libssl-dev libcurl4-openssl-dev
 
 # RUN apk -v update \

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Only if you want to use our recommended pipeline to align RNAseq reads):
 * [STAR2.7](https://github.com/alexdobin/STAR)  - set location as $STAR
 * [Trimmomatic](https://github.com/usadellab/Trimmomatic) - set location as $trimmomatic_path
 * [vcftools0.1.15](https://vcftools.github.io/)
+* [tabix](https://github.com/samtools/htslib)
 
 The following tools are required to install and run BEASTIE directly on your system:
 * BEASTIE has been tested on **Linux**. It may or may not work on other UNIX systems.


### PR DESCRIPTION
1) Changes base image for building beastie
This ensures that the compiled BEASTIE model can run in the target
Docker image.

2) Adds tabix dependency to dockerfile and README

Thanks to @zackgomez for these changes.