### PR TITLE
Generates full path information for R files called from python

### DIFF
--- a/BEASTIE/annotation.py
+++ b/BEASTIE/annotation.py
@@ -7,6 +7,7 @@ import os
 
 import pandas as pd
 
+from pkg_resources import resource_filename
 
 def annotateAF(ancestry, hetSNP, out_AF, ref_dir):
     AF_file = os.path.join(ref_dir, "AF_1_22.tsv")
@@ -38,9 +39,11 @@ def annotateAF(ancestry, hetSNP, out_AF, ref_dir):
         logging.info('..... skip annotating AF for SNPs, file already saved at {0}'.format(out_AF))
 
 def annotateLD(prefix,ancestry,hetSNP_intersect_unique,out,LD_token,chr_start,chr_end,meta):
+    annotate_ld_new = resource_filename('BEASTIE', 'annotate_LD_new.R')
+
     if not os.path.isfile(meta):
-        cmd="Rscript --vanilla annotate_LD_new.R %s %s %s %s %s %d %d %s"%(prefix,ancestry,hetSNP_intersect_unique,out,LD_token,int(chr_start),int(chr_end),meta)
+        cmd = f"Rscript --vanilla {annotate_ld_new} {prefix} {ancestry} {hetSNP_intersect_unique} {out} {LD_token} {chr_start} {chr_end} {meta}"
         os.system(cmd)
-        logging.info('..... finish annotating LD for SNP pairs, file save at {0}'.format(meta))
+        logging.info(f"..... finish annotating LD for SNP pairs, file save at {meta}")
     else:
-        logging.info('..... skip annotating LD for SNP pairs, file already saved at {0}'.format(meta))
+        logging.info(f"..... skip annotating LD for SNP pairs, file already saved at {meta}")

--- a/BEASTIE/beastie_step2.py
+++ b/BEASTIE/beastie_step2.py
@@ -12,6 +12,8 @@ import BEASTIE.ADM_for_real_data as ADM_for_real_data
 import BEASTIE.binomial_for_real_data as binomial_for_real_data
 import BEASTIE.run_model_stan_wrapper as run_model_stan_wrapper
 
+from pkg_resources import resource_filename
+
 from .beastie_step1 import create_output_directory
 from .prepare_model import (generate_modelCount, significant_genes,
                             update_model_input_lambda_phasing)
@@ -45,9 +47,9 @@ def run(hetSNP_intersect_unique,meta,hetSNP_intersect_unique_forlambda_file,hetS
     else:
         logging.info('..... data exists, overwrites and saves at {0}'.format(hetSNP_intersect_unique_lambdaPredicted_file))
         logging.info('..... data exists, overwrites and saves at {0}'.format(meta_error))
-    cmd="Rscript --vanilla predict_lambda_phasingError.R %s %s %s %s %s %s %s %s %s"%(
-            alpha,common,prefix,model,hetSNP_intersect_unique,hetSNP_intersect_unique_forlambda_file,hetSNP_intersect_unique_lambdaPredicted_file,meta,meta_error
-        )
+
+    predict_lambda_phasing_error = resource_filename('BEASTIE', 'predict_lambda_phasingError.R')
+    cmd = f"Rscript --vanilla {predict_lambda_phasing_error} {alpha} {common} {prefix} {model} {hetSNP_intersect_unique} {hetSNP_intersect_unique_forlambda_file} {hetSNP_intersect_unique_lambdaPredicted_file} {meta} {meta_error}"
     os.system(cmd)
     data22=pd.read_csv(hetSNP_intersect_unique_lambdaPredicted_file,sep="\t",header=0,index_col=False)
     logging.info('..... For type 1 error model, input alpha (family wise error rate) is {0}, adjusted after size of input {1} : {2}'.format(alpha,data22.shape[0],alpha/data22.shape[0]))

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,3 +23,4 @@ package_dir =
     BEASTIE=BEASTIE
 scripts =
     bin/beastie
+zip_safe = False


### PR DESCRIPTION
To call the R files in the BEASTIE directory from Rscript using os.system the full path needs to be passed to Rscript. Otherwise Rscript will look in the current working directory -- the directory the user was in when the ran the `beastie` command -- and will fail because the files won't be found.

I think this will fix https://github.com/x811zou/BEASTIE/issues/15