### PR TITLE
fix r path errors

### DIFF
--- a/BEASTIE/annotate_LD_new.R
+++ b/BEASTIE/annotate_LD_new.R
@@ -4,7 +4,7 @@ suppressMessages(library(data.table))
 suppressMessages(library(foreach))
 suppressMessages(library("dplyr"))
 library("LDlinkR")
-source("Get_LD.R")
+source("./BEASTIE/Get_LD.R")
 
 args = commandArgs(trailingOnly=TRUE)
 prefix=args[1]

--- a/BEASTIE/annotate_LD_new.R
+++ b/BEASTIE/annotate_LD_new.R
@@ -4,7 +4,6 @@ suppressMessages(library(data.table))
 suppressMessages(library(foreach))
 suppressMessages(library("dplyr"))
 library("LDlinkR")
-source("./BEASTIE/Get_LD.R")
 
 args = commandArgs(trailingOnly=TRUE)
 prefix=args[1]
@@ -15,6 +14,9 @@ mytoken=args[5]
 chr_start=args[6]
 chr_end=args[7]
 meta=args[8]
+beastie_wd=args[9]
+
+source(file.path(beastie_wd, "Get_LD.R"))
 
 if (!file.exists(meta)){
 #================================================ specify input

--- a/BEASTIE/annotation.py
+++ b/BEASTIE/annotation.py
@@ -7,7 +7,7 @@ import os
 
 import pandas as pd
 
-from pkg_resources import resource_filename, resource_dir
+from pkg_resources import resource_filename
 
 def annotateAF(ancestry, hetSNP, out_AF, ref_dir):
     AF_file = os.path.join(ref_dir, "AF_1_22.tsv")

--- a/BEASTIE/annotation.py
+++ b/BEASTIE/annotation.py
@@ -7,7 +7,7 @@ import os
 
 import pandas as pd
 
-from pkg_resources import resource_filename
+from pkg_resources import resource_filename, resource_dir
 
 def annotateAF(ancestry, hetSNP, out_AF, ref_dir):
     AF_file = os.path.join(ref_dir, "AF_1_22.tsv")
@@ -40,9 +40,10 @@ def annotateAF(ancestry, hetSNP, out_AF, ref_dir):
 
 def annotateLD(prefix,ancestry,hetSNP_intersect_unique,out,LD_token,chr_start,chr_end,meta):
     annotate_ld_new = resource_filename('BEASTIE', 'annotate_LD_new.R')
+    beastie_wd = resource_filename('BEASTIE', '.')
 
     if not os.path.isfile(meta):
-        cmd = f"Rscript --vanilla {annotate_ld_new} {prefix} {ancestry} {hetSNP_intersect_unique} {out} {LD_token} {chr_start} {chr_end} {meta}"
+        cmd = f"Rscript --vanilla {annotate_ld_new} {prefix} {ancestry} {hetSNP_intersect_unique} {out} {LD_token} {chr_start} {chr_end} {meta} {beastie_wd}"
         os.system(cmd)
         logging.info(f"..... finish annotating LD for SNP pairs, file save at {meta}")
     else:

--- a/BEASTIE/beastie_step2.py
+++ b/BEASTIE/beastie_step2.py
@@ -49,7 +49,8 @@ def run(hetSNP_intersect_unique,meta,hetSNP_intersect_unique_forlambda_file,hetS
         logging.info('..... data exists, overwrites and saves at {0}'.format(meta_error))
 
     predict_lambda_phasing_error = resource_filename('BEASTIE', 'predict_lambda_phasingError.R')
-    cmd = f"Rscript --vanilla {predict_lambda_phasing_error} {alpha} {common} {prefix} {model} {hetSNP_intersect_unique} {hetSNP_intersect_unique_forlambda_file} {hetSNP_intersect_unique_lambdaPredicted_file} {meta} {meta_error}"
+    beastie_wd = resource_filename('BEASTIE', '.')
+    cmd = f"Rscript --vanilla {predict_lambda_phasing_error} {alpha} {common} {prefix} {model} {hetSNP_intersect_unique} {hetSNP_intersect_unique_forlambda_file} {hetSNP_intersect_unique_lambdaPredicted_file} {meta} {meta_error} {beastie_wd}"
     os.system(cmd)
     data22=pd.read_csv(hetSNP_intersect_unique_lambdaPredicted_file,sep="\t",header=None,index_col=False) # check whether this data is generated, debugging purpose
     logging.info('..... For type 1 error model, input alpha (family wise error rate) is {0}, adjusted after size of input {1} : {2}'.format(alpha,data22.shape[0],alpha/data22.shape[0]))

--- a/BEASTIE/predict_lambda_phasingError.R
+++ b/BEASTIE/predict_lambda_phasingError.R
@@ -52,8 +52,8 @@ meta_error=args[9]
 # meta="/Users/scarlett/Documents/Allen_lab/github/BEASTIE/BEASTIE_example/HG00096_chr21/output/TEMP/HG00096_chr21_meta.tsv"
 # meta_error="/Users/scarlett/Documents/Allen_lab/github/BEASTIE/BEASTIE_example/HG00096_chr21/output/HG00096_chr21_meta_w_error.tsv"
 
-source("Get_phasing_error_rate.R")
-source("Get_LD.R")
+source("./BEASTIE/Get_phasing_error_rate.R")
+source("./BEASTIE/Get_LD.R")
 
 predict_lambda_realdata <- function(alpha,in_data,out_data){
   #colnames(in_data)<-c("gene_ID","total_reads","num_hets")
@@ -68,9 +68,9 @@ predict_lambda_realdata <- function(alpha,in_data,out_data){
 
 ############################################## 1. predict lambda #####################################################
 if(grepl("iBEASTIE", model, fixed=TRUE)){
-  lambda.fit.simulation<- readRDS("LinearReg_iBEASTIE_fitted_model_lambda.rds")
+  lambda.fit.simulation<- readRDS("./BEASTIE/LinearReg_iBEASTIE_fitted_model_lambda.rds")
 }else{
-  lambda.fit.simulation<- readRDS("LinearReg_BEASTIE_fitted_model_lambda.rds")
+  lambda.fit.simulation<- readRDS("./BEASTIE/LinearReg_BEASTIE_fitted_model_lambda.rds")
 }
 
 in_data<-read.delim(file.path(hetSNP_intersect_unique_forlambda_file),header=TRUE,sep="\t") 

--- a/BEASTIE/predict_lambda_phasingError.R
+++ b/BEASTIE/predict_lambda_phasingError.R
@@ -33,14 +33,15 @@ library(glmnetUtils)
 #### read in parameters
 
 alpha=args[1]
-tmp=paste0(args[2],"/",sep="")                     
-sample=args[3]                                     
-model=args[4]                                      
-hetSNP_intersect_unique=args[5]                    
-hetSNP_intersect_unique_forlambda_file=args[6]     
+tmp=paste0(args[2],"/",sep="")
+sample=args[3]
+model=args[4]
+hetSNP_intersect_unique=args[5]
+hetSNP_intersect_unique_forlambda_file=args[6]
 hetSNP_intersect_unique_lambdaPredicted_file=args[7]
-meta=args[8]                                       
-meta_error=args[9]                                 
+meta=args[8]
+meta_error=args[9]
+beastie_wd=args[10]
 
 # alpha=0.05 #FWE
 # sample="HG00096_chr21"
@@ -52,8 +53,8 @@ meta_error=args[9]
 # meta="/Users/scarlett/Documents/Allen_lab/github/BEASTIE/BEASTIE_example/HG00096_chr21/output/TEMP/HG00096_chr21_meta.tsv"
 # meta_error="/Users/scarlett/Documents/Allen_lab/github/BEASTIE/BEASTIE_example/HG00096_chr21/output/HG00096_chr21_meta_w_error.tsv"
 
-source("./BEASTIE/Get_phasing_error_rate.R")
-source("./BEASTIE/Get_LD.R")
+source(file.path(beastie_wd, "Get_phasing_error_rate.R"))
+source(file.path(beastie_wd, "Get_LD.R"))
 
 predict_lambda_realdata <- function(alpha,in_data,out_data){
   #colnames(in_data)<-c("gene_ID","total_reads","num_hets")
@@ -68,12 +69,12 @@ predict_lambda_realdata <- function(alpha,in_data,out_data){
 
 ############################################## 1. predict lambda #####################################################
 if(grepl("iBEASTIE", model, fixed=TRUE)){
-  lambda.fit.simulation<- readRDS("./BEASTIE/LinearReg_iBEASTIE_fitted_model_lambda.rds")
+  lambda.fit.simulation<- readRDS(file.path(beastie_wd, "LinearReg_iBEASTIE_fitted_model_lambda.rds"))
 }else{
-  lambda.fit.simulation<- readRDS("./BEASTIE/LinearReg_BEASTIE_fitted_model_lambda.rds")
+  lambda.fit.simulation<- readRDS(file.path(beastie_wd, "LinearReg_BEASTIE_fitted_model_lambda.rds"))
 }
 
-in_data<-read.delim(file.path(hetSNP_intersect_unique_forlambda_file),header=TRUE,sep="\t") 
+in_data<-read.delim(file.path(hetSNP_intersect_unique_forlambda_file),header=TRUE,sep="\t")
 
 size=dim(in_data)[1]
 out_data<-hetSNP_intersect_unique_lambdaPredicted_file

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include requirements.txt
 include BEASTIE/*.R
+include BEASTIE/*.rds


### PR DESCRIPTION
This updates the paths inside the .R files to work when run with the working directory as the root of the project, as occurs in the docker image.

I have only tested this change against the docker image, so it might be broken when run in the traditional manner.

One possible improvement would be to thread the python package dir from @tncowart recent commit as an argument to the R scripts which could create paths appropriately.  One issue would be recursive imports- I'm not sure how the R `source` function takes arguments but a `source`d file that needs to `source` other files would need the full path.  Perhaps an environment variable (`R_SOURCE_PREFIX` for example) is another solution instead of an argument to the scripts.