### PR TITLE
Constant memory use algorithm in annotateAF

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.formatting.provider": "black"
+}

--- a/BEASTIE/annotation.py
+++ b/BEASTIE/annotation.py
@@ -2,26 +2,24 @@
 # =========================================================================
 # 2021 Xue Zou (xue.zou@duke.edu)
 # =========================================================================
-from datetime import datetime
+import csv
+import gzip
 import logging
 import os
-import csv
-
+import pandas as pd
 from pkg_resources import resource_filename
 
-import pandas as pd
-
 from .helpers import runhelper
-
 
 USE_CONSTANT_MEMORY_ALGORITHM = True
 
 
 def annotateAF(ancestry, hetSNP, out_AF, ref_dir):
-    AF_file = os.path.join(ref_dir, "AF_1_22_trimmed2.csv")
     if USE_CONSTANT_MEMORY_ALGORITHM:
+        AF_file = os.path.join(ref_dir, "AF_1_22_trimmed2.csv.gz")
         annotateAFConstantMemory(ancestry, hetSNP, out_AF, AF_file)
     else:
+        AF_file = os.path.join(ref_dir, "AF_1_22_trimmed2.csv")
         annotateAFPandas(ancestry, hetSNP, out_AF, AF_file)
 
     logging.info("..... finish annotating AF for SNPs, file save at {0}".format(out_AF))
@@ -57,7 +55,7 @@ def annotateAFPandas(ancestry, hetSNP, out_AF, AF_file):
 def annotateAFConstantMemory(ancestry, hetSNP, out_AF, AF_file):
     logging.info("..... start annotating AF with constant memory join")
 
-    with open(AF_file, newline="") as affile, open(
+    with gzip.open(AF_file, mode="rt", newline="") as affile, open(
         hetSNP, newline=""
     ) as hetSNPfile, open(out_AF, "w", newline="") as outFile:
         af_reader = csv.reader(affile, delimiter=",", dialect="unix")

--- a/BEASTIE/annotation.py
+++ b/BEASTIE/annotation.py
@@ -25,6 +25,8 @@ def annotateAF(ancestry, hetSNP, out_AF, ref_dir):
         annotateAFPandas(ancestry, hetSNP, out_AF, AF_file)
 
     logging.info("..... finish annotating AF for SNPs, file save at {0}".format(out_AF))
+    # @nocommit
+    exit(0)
 
 
 def annotateAFPandas(ancestry, hetSNP, out_AF, AF_file):

--- a/BEASTIE/annotation.py
+++ b/BEASTIE/annotation.py
@@ -23,8 +23,6 @@ def annotateAF(ancestry, hetSNP, out_AF, ref_dir):
         annotateAFPandas(ancestry, hetSNP, out_AF, AF_file)
 
     logging.info("..... finish annotating AF for SNPs, file save at {0}".format(out_AF))
-    # @nocommit
-    exit(0)
 
 
 def annotateAFPandas(ancestry, hetSNP, out_AF, AF_file):

--- a/BEASTIE/annotation.py
+++ b/BEASTIE/annotation.py
@@ -16,7 +16,7 @@ USE_CONSTANT_MEMORY_ALGORITHM = True
 
 def annotateAF(ancestry, hetSNP, out_AF, ref_dir):
     if USE_CONSTANT_MEMORY_ALGORITHM:
-        AF_file = os.path.join(ref_dir, "AF_1_22_chr20.csv.gz")
+        AF_file = os.path.join(ref_dir, "AF_1_22_trimmed2.csv.gz")
         annotateAFConstantMemory(ancestry, hetSNP, out_AF, AF_file)
     else:
         AF_file = os.path.join(ref_dir, "AF_1_22_trimmed2.csv")

--- a/BEASTIE/annotation.py
+++ b/BEASTIE/annotation.py
@@ -2,8 +2,10 @@
 # =========================================================================
 # 2021 Xue Zou (xue.zou@duke.edu)
 # =========================================================================
+from datetime import datetime
 import logging
 import os
+import csv
 
 from pkg_resources import resource_filename
 
@@ -12,42 +14,96 @@ import pandas as pd
 from .helpers import runhelper
 
 
+USE_CONSTANT_MEMORY_ALGORITHM = True
+
+
 def annotateAF(ancestry, hetSNP, out_AF, ref_dir):
     AF_file = os.path.join(ref_dir, "AF_1_22_trimmed2.csv")
-    if not os.path.isfile(out_AF):
-        logging.info("..... start reading 1000 Genome AF annotation file")
-        AF = pd.read_csv(AF_file, header=0, sep=",", engine="c", na_filter=False)
-        logging.info("..... finish reading 1000 Genome AF annotation file")
-        # hetSNP="NA19248_hetSNP_chr1-22.tsv"
-        data = pd.read_csv(hetSNP, sep="\t", header=0, index_col=False)
-        if ancestry == "EUR":
-            AF = AF[["chr", "pos", "rsid", "EUR_AF"]]
-            AF = AF.rename(columns={"EUR_AF": "AF"})
-        elif ancestry == "AFR":
-            AF = AF[["chr", "pos", "rsid", "AFR_AF"]]
-            AF = AF.rename(columns={"AFR_AF": "AF"})
-        elif ancestry == "EAS":
-            AF = AF[["chr", "pos", "rsid", "EAS_AF"]]
-            AF = AF.rename(columns={"EAS_AF": "AF"})
-        elif ancestry == "AMR":
-            AF = AF[["chr", "pos", "rsid", "AMR_AF"]]
-            AF = AF.rename(columns={"AMR_AF": "AF"})
-        elif ancestry == "SAS":
-            AF = AF[["chr", "pos", "rsid", "SAS_AF"]]
-            AF = AF.rename(columns={"SAS_AF": "AF"})
-        data_AF = pd.merge(data, AF, on=["chr", "pos"], how="left")
-        data_AF = data_AF.drop_duplicates()
-        # out_AF="NA19248_hetSNP_chr1-22_AF.tsv"
-        data_AF.to_csv(out_AF, sep="\t")
-        logging.info(
-            "..... finish annotating AF for SNPs, file save at {0}".format(out_AF)
-        )
+    if USE_CONSTANT_MEMORY_ALGORITHM:
+        annotateAFConstantMemory(ancestry, hetSNP, out_AF, AF_file)
     else:
-        logging.info(
-            "..... skip annotating AF for SNPs, file already saved at {0}".format(
-                out_AF
-            )
-        )
+        annotateAFPandas(ancestry, hetSNP, out_AF, AF_file)
+
+    logging.info("..... finish annotating AF for SNPs, file save at {0}".format(out_AF))
+
+
+def annotateAFPandas(ancestry, hetSNP, out_AF, AF_file):
+    logging.info("..... start reading 1000 Genome AF annotation file")
+    AF = pd.read_csv(AF_file, header=0, sep=",", engine="c", na_filter=False)
+    logging.info("..... finish reading 1000 Genome AF annotation file")
+    data = pd.read_csv(hetSNP, sep="\t", header=0, index_col=False)
+    if ancestry == "EUR":
+        AF = AF[["chr", "pos", "rsid", "EUR_AF"]]
+        AF = AF.rename(columns={"EUR_AF": "AF"})
+    elif ancestry == "AFR":
+        AF = AF[["chr", "pos", "rsid", "AFR_AF"]]
+        AF = AF.rename(columns={"AFR_AF": "AF"})
+    elif ancestry == "EAS":
+        AF = AF[["chr", "pos", "rsid", "EAS_AF"]]
+        AF = AF.rename(columns={"EAS_AF": "AF"})
+    elif ancestry == "AMR":
+        AF = AF[["chr", "pos", "rsid", "AMR_AF"]]
+        AF = AF.rename(columns={"AMR_AF": "AF"})
+    elif ancestry == "SAS":
+        AF = AF[["chr", "pos", "rsid", "SAS_AF"]]
+        AF = AF.rename(columns={"SAS_AF": "AF"})
+    data_AF = pd.merge(data, AF, on=["chr", "pos"], how="left")
+    data_AF = data_AF.drop_duplicates()
+    data_AF.to_csv(out_AF, sep="\t")
+
+
+def annotateAFConstantMemory(ancestry, hetSNP, out_AF, AF_file):
+    logging.info("..... start annotating AF with constant memory join")
+
+    with open(AF_file, newline="") as affile, open(
+        hetSNP, newline=""
+    ) as hetSNPfile, open(out_AF, "w", newline="") as outFile:
+        af_reader = csv.reader(affile, delimiter=",", dialect="unix")
+        hetSNP_reader = csv.reader(hetSNPfile, delimiter="\t", dialect="unix")
+        out_writer = csv.writer(outFile, delimiter="\t", dialect="unix")
+
+        af_header = next(af_reader)
+        hetSNP_header = next(hetSNP_reader)
+
+        hetSNP_chr_index = hetSNP_header.index("chr")
+        hetSNP_pos_index = hetSNP_header.index("pos")
+
+        af_chr_index = af_header.index("chr")
+        af_pos_index = af_header.index("pos")
+        af_af_col_index = af_header.index(f"{ancestry}_AF")
+        af_rsid_col_index = af_header.index("rsid")
+
+        af_rows_left = True
+
+        af_row = next(af_reader)
+        af_chr, af_pos = af_row[af_chr_index], int(af_row[af_pos_index])
+        af_chr_n = int(af_chr.strip("chr"))
+
+        rows_written = 0
+        rows_read = 0
+
+        for row in hetSNP_reader:
+            chr, pos = row[hetSNP_chr_index], int(row[hetSNP_pos_index])
+            chr_n = int(chr.strip("chr"))
+
+            while af_rows_left and (chr_n > af_chr_n or pos > af_pos):
+                try:
+                    af_row = next(af_reader)
+                    af_chr, af_pos = af_row[af_chr_index], int(af_row[af_pos_index])
+                    af_chr_n = int(af_chr.strip("chr"))
+                    rows_read += 1
+                except StopIteration:
+                    af_row = None
+                    af_rows_left = False
+
+            if af_row is not None:
+                out_writer.writerow(
+                    row + [af_row[af_af_col_index], af_row[af_rsid_col_index]]
+                )
+            else:
+                out_writer.writerow(row + ["", ""])
+            rows_written += 1
+    logging.info("..... end annotating AF")
 
 
 def annotateLD(

--- a/BEASTIE/beastie_step1.py
+++ b/BEASTIE/beastie_step1.py
@@ -362,9 +362,7 @@ def run(
 
     ##### 1.3 Annotation: AF
     hetSNP_AF = f"{os.path.splitext(hetSNP)[0]}_AF.tsv"
-    # @nocommit
-    # if os.path.isfile(hetSNP_AF):
-    if False:
+    if os.path.isfile(hetSNP_AF):
         logging.info("=================")
         logging.info("================= Skipping common step 1.3")
         data13 = pd.read_csv(hetSNP_AF, sep="\t", header=0, index_col=False)

--- a/BEASTIE/beastie_step1.py
+++ b/BEASTIE/beastie_step1.py
@@ -362,8 +362,9 @@ def run(
 
     ##### 1.3 Annotation: AF
     hetSNP_AF = f"{os.path.splitext(hetSNP)[0]}_AF.tsv"
-    # print(hetSNP_AF)
-    if os.path.isfile(hetSNP_AF):
+    # @nocommit
+    # if os.path.isfile(hetSNP_AF):
+    if False:
         logging.info("=================")
         logging.info("================= Skipping common step 1.3")
         data13 = pd.read_csv(hetSNP_AF, sep="\t", header=0, index_col=False)

--- a/BEASTIE/extractHets.py
+++ b/BEASTIE/extractHets.py
@@ -98,10 +98,7 @@ def count_all_het_sites(
                 if len(output) > 0:
                     outputs.append(output)
 
-            out_stream = open(outputFile, "w")
-            out_stream.write(
-                "chr\tchrN\tgeneID\tpos\ttranscriptID\ttranscript_pos\tSNP_id\tgenotype\n"
-            )
+            data = []
             for output in outputs:
                 lines = output.split("\n")
                 transcripts = None
@@ -131,25 +128,32 @@ def count_all_het_sites(
                     for transcript in transcripts:
                         transcriptCoord = transcript.mapToTranscript(pos)
                         chrom = transcript.getSubstrate()
-                        chromN = chrom.strip("chr")
+                        chromN = int(chrom.strip("chr"))
                         total_biSNP += 1
                         chr_pos = f"{chromN}_{pos}"
                         byGene[geneID].add(chr_pos)
-                        out_stream.write(
-                            "\t".join(
-                                [
-                                    str(chrom),
-                                    str(chromN),
-                                    str(transcript.getGeneId()),
-                                    str(pos),
-                                    str(transcript.getTranscriptId()),
-                                    str(transcriptCoord),
-                                    str(rs),
-                                    str(genotype),
-                                ]
-                            )
+                        data.append(
+                            [
+                                chrom,
+                                chromN,
+                                transcript.getGeneId(),
+                                pos,
+                                transcript.getTranscriptId(),
+                                transcriptCoord,
+                                rs,
+                                genotype,
+                            ]
                         )
-                        out_stream.write("\n")
+
+            data.sort(key=lambda r: (r[1], r[3]))
+
+            out_stream = open(outputFile, "w")
+            out_stream.write(
+                "chr\tchrN\tgeneID\tpos\ttranscriptID\ttranscript_pos\tSNP_id\tgenotype\n"
+            )
+            for r in data:
+                out_stream.write("\t".join(map(str, r)))
+                out_stream.write("\n")
 
             out_stream.close()
         else:

--- a/BEASTIE/parameters_HG_chr21.cfg
+++ b/BEASTIE/parameters_HG_chr21.cfg
@@ -23,7 +23,7 @@ WARMUP=1000
 KEEPER=1000
 
 [outputs]
-out_path=/home/osboxes/programming/BEASTIE/BEASTIE_example/        
+out_path=/Users/scarlett/Documents/Allen_lab/github/BEASTIE/BEASTIE_example/        
 
 
 

--- a/BEASTIE/parameters_HG_chr21.cfg
+++ b/BEASTIE/parameters_HG_chr21.cfg
@@ -23,7 +23,7 @@ WARMUP=1000
 KEEPER=1000
 
 [outputs]
-out_path=/Users/scarlett/Documents/Allen_lab/github/BEASTIE/BEASTIE_example/        
+out_path=/home/osboxes/programming/BEASTIE/BEASTIE_example/        
 
 
 


### PR DESCRIPTION
1. Sort hetSNP output from step 1.1
2. Use a line-by-line join relying on sorted input files to use constant memory
3. Also directly read the .gz reference file saving disk space